### PR TITLE
fix: resolve wishlist id

### DIFF
--- a/includes/api/wishlist.class.php
+++ b/includes/api/wishlist.class.php
@@ -174,7 +174,7 @@ class TInvWL_Includes_API_Wishlist {
 
 		$wlp  = new TInvWL_Product();
 		$args = [
-			'wishlist_id' => $wishlist['ID'],
+			'wishlist_id' => $wishlist['wishlist']['ID'],
 			'external'    => false,
 			'count'       => $request->get_param( 'count' ),
 			'offset'      => $request->get_param( 'offset' ),
@@ -210,8 +210,8 @@ class TInvWL_Includes_API_Wishlist {
 
 		$wlp  = new TInvWL_Product();
 		$args = [
-			'wishlist_id'  => $wishlist['ID'],
-			'author'       => $wishlist['author'],
+			'wishlist_id'  => $wishlist['wishlist']['ID'],
+			'author'       => $wishlist['wishlist']['author'],
 			'product_id'   => absint( $request->get_param( 'product_id' ) ),
 			'variation_id' => absint( $request->get_param( 'variation_id' ) ),
 		];


### PR DESCRIPTION
This is a fix for the **WISHLISTS REST API**. 
We were facing an issue in our project, that it was not possible to get the wishlist products by a share_key of a given user.
Additionally it was not possible to add a product to the wishlist.
Many developers were also reporting that issue, for example [here](https://wordpress.org/support/topic/api-not-working-10/) and [here](https://wordpress.org/support/topic/always-get-the-error-products-not-found-for-a-valid-product/).

I could debug that issue and found out that the `get_wishlist_by_share_key` method returned an array with different properties. Some of the endpoints that are using that method to retrieve the wishlist id did not access the right property on the array and therefore the operations were not successful.
I already tried the fix and it works like a charm, it would be great if you could integrate those fixes into your plugin and release a new version.

Thanks in advance!

Sincerely
widdy